### PR TITLE
Add latest Slack stats from 2015-12-1

### DIFF
--- a/slack_stats.tsv
+++ b/slack_stats.tsv
@@ -1,82 +1,82 @@
-Users	2015-11-28T12:12:18.872Z	2015-11-29T23:37:19.706Z	2015-11-30T23:10:18.669Z
-1st_panzer_division	7	9	12
-aarohmankad	9	9	9
-aashiamehta	0	0	0
-abenezer_mamo	67	67	67
-ad510	346	346	346
-alexb	6401	6472	6604
-alexwong	2	2	2
-allison	75	75	75
-allyson	0	0	0
-amedina2016	0	0	0
-amir	84	86	86
-amirt01	16	16	16
-amitsin6h	33	35	51
-amysorto	306	308	309
-an.ng.huynh	31	31	31
-applejack	43	43	43
-applemaster	36	36	36
-asso	10	10	10
-bogdan_vitoc	405	405	405
-bot-jonathan	17	17	17
-briann	69	71	73
-bwmaniac	25	25	25
-c			2218
-cathy	21	21	21
-cbarbosa2016	0	0	0
-chaoyi	2085	2136	
-conrad	19	19	19
-dan	139	139	139
-dannysaur	14	14	14
-darrylyeo	0	0	0
-ddollar	7	7	7
-doglover101	1410	1416	1416
-edjiang	5	5	5
-ful_potatis	3	3	3
-gemma	112	112	115
-gialonk	23	23	23
-hardmath123	1825	1836	1847
-harrison	4269	4293	4314
-hellyeah	2569	2570	2570
-janetfang	12	12	12
-jasmine_lovesadipose	304	304	304
-jensslack123	4	4	4
-jessica	34	34	34
-jevin	340	343	349
-jiahaok	77	77	77
-jlin0104	98	98	98
-jonl	3099	3099	3124
-jonwlee	58	58	58
-josh	8	8	8
-justinyu	26	26	26
-kern	0	0	0
-krizia.araracap	8	8	8
-ktsai	10	10	10
-leilaaimee	1268	1270	1280
-mahahahajan	185	185	185
-metmets	297	315	341
-mhesby	1271	1271	1293
-msw	1504	1557	1579
-phillip	17	17	17
-rafe	8	8	8
-renee	7	7	7
-rodney	5	5	5
-saescapa	249	281	282
-salamander1012	29	29	29
-sely	3566	3579	3586
-seth	106	126	174
-shane	109	109	109
-slackin	0	0	0
-sneharamapo	0	0	0
-tejas	184	185	185
-teresa	46	46	46
-thebigch33se	12	12	12
-thethirdone	54	64	65
-udit	112	115	117
-vaibhav	199	199	212
-victor	26	26	38
-whelton	230	230	230
-yash	8	8	8
-yashweek	4	4	4
-zachcmiel	107	111	119
-zrl	5580	5597	5686
+Users	2015-11-28T12:12:18.872Z	2015-11-29T23:37:19.706Z	2015-11-30T23:10:18.669Z	2015-12-01T10:29:49.270Z
+1st_panzer_division	7	9	12	12
+aarohmankad	9	9	9	9
+aashiamehta	0	0	0	0
+abenezer_mamo	67	67	67	67
+ad510	346	346	346	346
+alexb	6401	6472	6604	6685
+alexwong	2	2	2	2
+allison	75	75	75	75
+allyson	0	0	0	0
+amedina2016	0	0	0	0
+amir	84	86	86	86
+amirt01	16	16	16	16
+amitsin6h	33	35	51	51
+amysorto	306	308	309	311
+an.ng.huynh	31	31	31	31
+applejack	43	43	43	47
+applemaster	36	36	36	36
+asso	10	10	10	10
+bogdan_vitoc	405	405	405	405
+bot-jonathan	17	17	17	17
+briann	69	71	73	73
+bwmaniac	25	25	25	25
+c	0	0	2218	2340
+cathy	21	21	21	21
+cbarbosa2016	0	0	0	0
+chaoyi	2085	2136	0	
+conrad	19	19	19	19
+dan	139	139	139	139
+dannysaur	14	14	14	14
+darrylyeo	0	0	0	0
+ddollar	7	7	7	7
+doglover101	1410	1416	1416	1467
+edjiang	5	5	5	5
+ful_potatis	3	3	3	3
+gemma	112	112	115	120
+gialonk	23	23	23	23
+hardmath123	1825	1836	1847	1911
+harrison	4269	4293	4314	4394
+hellyeah	2569	2570	2570	2575
+janetfang	12	12	12	12
+jasmine_lovesadipose	304	304	304	323
+jensslack123	4	4	4	4
+jessica	34	34	34	34
+jevin	340	343	349	350
+jiahaok	77	77	77	77
+jlin0104	98	98	98	99
+jonl	3099	3099	3124	3205
+jonwlee	58	58	58	58
+josh	8	8	8	8
+justinyu	26	26	26	26
+kern	0	0	0	0
+krizia.araracap	8	8	8	8
+ktsai	10	10	10	10
+leilaaimee	1268	1270	1280	1337
+mahahahajan	185	185	185	185
+metmets	297	315	341	345
+mhesby	1271	1271	1293	1366
+msw	1504	1557	1579	1668
+phillip	17	17	17	17
+rafe	8	8	8	8
+renee	7	7	7	7
+rodney	5	5	5	5
+saescapa	249	281	282	298
+salamander1012	29	29	29	29
+sely	3566	3579	3586	3609
+seth	106	126	174	181
+shane	109	109	109	109
+slackin	0	0	0	0
+sneharamapo	0	0	0	0
+tejas	184	185	185	185
+teresa	46	46	46	46
+thebigch33se	12	12	12	12
+thethirdone	54	64	65	65
+udit	112	115	117	117
+vaibhav	199	199	212	212
+victor	26	26	38	38
+whelton	230	230	230	230
+yash	8	8	8	8
+yashweek	4	4	4	4
+zachcmiel	107	111	119	119
+zrl	5580	5597	5686	5840


### PR DESCRIPTION
This pull request adds the latest Slack stats from 2015-12-1 to the `slack_stats.tsv` file.

As of Tue, 01 Dec 2015 10:29:49 GMT, there have been 41596 messages sent in the Slack. The most active user of all time is `alexb`, who has sent 6685 messages in total. The most active user in the past 7 days is `alexb`, who sent 1109 messages.

_Note: all times are UTC._

---

_This pull request is brought to you by [`slack-stats-collector`](https://github.com/hackclub/slack-stats-collector)_
